### PR TITLE
Fix imports in urls.py for Django 1.5

### DIFF
--- a/biblion/urls.py
+++ b/biblion/urls.py
@@ -1,6 +1,4 @@
-from django.conf.urls.defaults import *
-
-from django.views.generic.simple import direct_to_template
+from django.conf.urls import patterns, url
 
 
 urlpatterns = patterns("",


### PR DESCRIPTION
Update an import statement that no longer works in Django 1.5.

(Also remove one that isn't used.)
