### PR TITLE
Better section view

### DIFF
--- a/pinax/blog/forms.py
+++ b/pinax/blog/forms.py
@@ -62,7 +62,7 @@ class AdminPostForm(forms.ModelForm):
         # grab the latest revision of the Post instance
         latest_revision = post.latest()
 
-        self.fields["tags"].required = False
+        #self.fields["tags"].required = False
         if latest_revision:
             # set initial data from the latest revision
             self.fields["teaser"].initial = latest_revision.teaser

--- a/pinax/blog/urls.py
+++ b/pinax/blog/urls.py
@@ -4,7 +4,7 @@ from django.conf.urls import url, patterns
 urlpatterns = patterns(
     "pinax.blog.views",
     url(r'^$', "blog_index", name="blog"),
-    url(r'^section/(?P<section>[-\w]+)/$', "blog_section_list", name="blog_section"),
+    url(r'^section/(?P<section>[-\w]+)/$', "blog_index", name="blog_section"),
     url(r'^(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/(?P<slug>[-\w]+)/$', "blog_post_detail", name="blog_post"),
     url(r'^(?P<post_slug>[-\w]+)/$', "blog_post_detail", name="blog_post_slug"),
     url(r'^post/(?P<post_pk>\d+)/$', "blog_post_detail", name="blog_post_pk"),

--- a/pinax/blog/views.py
+++ b/pinax/blog/views.py
@@ -21,7 +21,6 @@ def blog_index(request, section=None):
     if section:
         try:
             posts = Post.objects.section(section)
-            print "posts count: " + str(posts.count())
         except InvalidSection:
             raise Http404()
     else:

--- a/pinax/blog/views.py
+++ b/pinax/blog/views.py
@@ -18,7 +18,6 @@ from .signals import post_viewed, post_redirected
 
 
 def blog_index(request, section=None):
-
     if section:
         try:
             posts = Post.objects.section(section)

--- a/pinax/blog/views.py
+++ b/pinax/blog/views.py
@@ -17,9 +17,16 @@ from .models import Post, FeedHit
 from .signals import post_viewed, post_redirected
 
 
-def blog_index(request):
+def blog_index(request, section=None):
 
-    posts = Post.objects.current()
+    if section:
+        try:
+            posts = Post.objects.section(section)
+            print "posts count: " + str(posts.count())
+        except InvalidSection:
+            raise Http404()
+    else:
+        posts = Post.objects.current()
 
     if request.GET.get("q"):
         posts = posts.filter(
@@ -32,21 +39,9 @@ def blog_index(request):
 
     return render_to_response("pinax/blog/blog_list.html", {
         "posts": posts,
-        "search_term": request.GET.get("q")
-    }, context_instance=RequestContext(request))
-
-
-def blog_section_list(request, section):
-
-    try:
-        posts = Post.objects.section(section)
-    except InvalidSection:
-        raise Http404()
-
-    return render_to_response("pinax/blog/blog_section_list.html", {
         "section_slug": section,
-        "section_name": dict(Post.SECTION_CHOICES)[Post.section_idx(section)],
-        "posts": posts,
+        "section_name": dict(Post.SECTION_CHOICES)[Post.section_idx(section)] if section else None,
+        "search_term": request.GET.get("q")
     }, context_instance=RequestContext(request))
 
 


### PR DESCRIPTION
blog_index view expanded to now do both blog_list view and section_list by having an optional section slug parameter. This also allows for searching (q parameter) of a single blog section.

The template for the blog_list.html will have to be a little smarter to optionally deal with section names, but it can keep the search form (if it has one) intact but it could then work (optionally) on the current section.

Had to comment out a reference to fields["tags"] for admin to function correctly.