### PR TITLE
Replaced default user model to use settings

### DIFF
--- a/pinax/blog/models.py
+++ b/pinax/blog/models.py
@@ -29,7 +29,6 @@ except ImportError:
     from string import ascii_letters as letters
 
 from random import choice
-from django.conf import settings
 
 def ig(L, i):
     for x in L:

--- a/pinax/blog/models.py
+++ b/pinax/blog/models.py
@@ -29,7 +29,7 @@ except ImportError:
     from string import ascii_letters as letters
 
 from random import choice
-
+from django.conf import settings
 
 def ig(L, i):
     for x in L:
@@ -54,7 +54,7 @@ class Post(models.Model):
 
     title = models.CharField(max_length=90)
     slug = models.SlugField(unique=settings.PINAX_BLOG_SLUG_UNIQUE)
-    author = models.ForeignKey(User, related_name="posts")
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="posts")
 
     markup = models.CharField(max_length=25, choices=settings.PINAX_BLOG_MARKUP_CHOICES)
 
@@ -227,7 +227,7 @@ class Revision(models.Model):
 
     content = models.TextField()
 
-    author = models.ForeignKey(User, related_name="revisions")
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="revisions")
 
     updated = models.DateTimeField(default=timezone.now)
     published = models.DateTimeField(null=True, blank=True)


### PR DESCRIPTION
As discussed on django documentation, there may be cases where user needs to add fields to his user model. In those cases the preferred way is to use a subclass of AbstractUser and change settings.AUTH_USER_MODEL. When that setting is not defined it will default to django's default user model. I had this issue and changing those lines allowed me to migrate without issues. This should not affect users with default settings.