### PR TITLE
#50, use model-based sections

### DIFF
--- a/pinax/blog/admin.py
+++ b/pinax/blog/admin.py
@@ -3,7 +3,7 @@ from django.utils import timezone
 from django.utils.functional import curry
 
 from .forms import AdminPostForm
-from .models import Post, Image, ReviewComment
+from .models import Post, Image, ReviewComment, Section
 from .utils import can_tweet
 
 
@@ -76,5 +76,11 @@ class PostAdmin(admin.ModelAdmin):
         return form.save()
 
 
+class SectionAdmin(admin.ModelAdmin):
+    prepopulated_fields = {"slug": ("name",)}
+
+
 admin.site.register(Post, PostAdmin)
 admin.site.register(Image)
+admin.site.register(Section, SectionAdmin)
+

--- a/pinax/blog/admin.py
+++ b/pinax/blog/admin.py
@@ -83,4 +83,3 @@ class SectionAdmin(admin.ModelAdmin):
 admin.site.register(Post, PostAdmin)
 admin.site.register(Image)
 admin.site.register(Section, SectionAdmin)
-

--- a/pinax/blog/managers.py
+++ b/pinax/blog/managers.py
@@ -1,8 +1,6 @@
 from django.db import models
-from django.db.models.query import Q
 
 from .conf import settings
-from .exceptions import InvalidSection
 
 
 PUBLISHED_STATE = len(settings.PINAX_BLOG_UNPUBLISHED_STATES) + 1

--- a/pinax/blog/managers.py
+++ b/pinax/blog/managers.py
@@ -15,18 +15,3 @@ class PostManager(models.Manager):
 
     def current(self):
         return self.published().order_by("-published")
-
-    def section(self, value, queryset=None):
-
-        if queryset is None:
-            queryset = self.published()
-
-        if not value:
-            return queryset
-        else:
-            try:
-                section_idx = self.model.section_idx(value)
-            except KeyError:
-                raise InvalidSection
-            all_sections = Q(section=self.model.section_idx(settings.PINAX_BLOG_ALL_SECTION_NAME))
-            return queryset.filter(all_sections | Q(section=section_idx))

--- a/pinax/blog/migrations/0003_auto_20150529_0405.py
+++ b/pinax/blog/migrations/0003_auto_20150529_0405.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('blog', '0002_post_state'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Section',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=150)),
+                ('slug', models.SlugField(unique=True)),
+                ('enabled', models.BooleanField(default=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AlterField(
+            model_name='post',
+            name='markup',
+            field=models.CharField(max_length=25, choices=[('markdown', 'Markdown')]),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='post',
+            name='section',
+            field=models.ForeignKey(to='blog.Section'),
+            preserve_default=True,
+        ),
+    ]

--- a/pinax/blog/migrations/0004_auto_20150530_1541.py
+++ b/pinax/blog/migrations/0004_auto_20150530_1541.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('blog', '0003_auto_20150529_0405'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='section',
+            name='name',
+            field=models.CharField(unique=True, max_length=150),
+            preserve_default=True,
+        ),
+    ]

--- a/pinax/blog/models.py
+++ b/pinax/blog/models.py
@@ -41,7 +41,7 @@ STATES = settings.PINAX_BLOG_UNPUBLISHED_STATES + ["Published"]
 PINAX_BLOG_STATE_CHOICES = list(zip(range(1, 1 + len(STATES)), STATES))
 
 class Section(models.Model):
-    name = models.CharField(max_length=150)
+    name = models.CharField(max_length=150,unique=True)
     slug = models.SlugField(unique=True)
     enabled = models.BooleanField(default=True)
 

--- a/pinax/blog/models.py
+++ b/pinax/blog/models.py
@@ -38,6 +38,7 @@ def ig(L, i):
 STATES = settings.PINAX_BLOG_UNPUBLISHED_STATES + ["Published"]
 PINAX_BLOG_STATE_CHOICES = list(zip(range(1, 1 + len(STATES)), STATES))
 
+
 class Section(models.Model):
     name = models.CharField(max_length=150, unique=True)
     slug = models.SlugField(unique=True)
@@ -45,6 +46,7 @@ class Section(models.Model):
 
     def __unicode__(self):
         return self.name
+
 
 class Post(models.Model):
 

--- a/pinax/blog/models.py
+++ b/pinax/blog/models.py
@@ -99,23 +99,6 @@ class Post(models.Model):
         if self.primary_image:
             return self.primary_image.image_path.url
 
-    @staticmethod
-    def section_idx(slug):
-        """
-        Return post section id. Keeping backward compatibility with idx based versions and templates. 
-        """
-        if slug != "all":
-            return Section.objects.get(slug=slug).pk
-        else:
-            return 0
-
-    @property
-    def section_slug(self):
-        """
-        Return post section slug
-        """
-        return self.section.slug 
-
     def rev(self, rev_id):
         return self.revisions.get(pk=rev_id)
 

--- a/pinax/blog/models.py
+++ b/pinax/blog/models.py
@@ -35,20 +35,16 @@ def ig(L, i):
     for x in L:
         yield x[i]
 
-
-
 STATES = settings.PINAX_BLOG_UNPUBLISHED_STATES + ["Published"]
 PINAX_BLOG_STATE_CHOICES = list(zip(range(1, 1 + len(STATES)), STATES))
 
 class Section(models.Model):
-    name = models.CharField(max_length=150,unique=True)
+    name = models.CharField(max_length=150, unique=True)
     slug = models.SlugField(unique=True)
     enabled = models.BooleanField(default=True)
 
     def __unicode__(self):
         return self.name
-
-
 
 class Post(models.Model):
 
@@ -256,5 +252,3 @@ class ReviewComment(models.Model):
     review_text = models.TextField()
     timestamp = models.DateTimeField(default=timezone.now)
     addressed = models.BooleanField(default=False)
-
-

--- a/pinax/blog/templatetags/pinax_blog_tags.py
+++ b/pinax/blog/templatetags/pinax_blog_tags.py
@@ -1,7 +1,6 @@
 from django import template
 
 from ..models import Post, Section
-from ..conf import settings
 
 
 register = template.Library()

--- a/pinax/blog/templatetags/pinax_blog_tags.py
+++ b/pinax/blog/templatetags/pinax_blog_tags.py
@@ -1,6 +1,6 @@
 from django import template
 
-from ..models import Post
+from ..models import Post, Section
 from ..conf import settings
 
 
@@ -52,7 +52,8 @@ class LatestSectionPostNode(template.Node):
 
     def render(self, context):
         section = self.section.resolve(context)
-        post = Post.objects.section(section, queryset=Post.objects.current())
+
+        post = Post.objects.published().filter(section__name=section).order_by("-published")
         try:
             post = post[0]
         except IndexError:
@@ -76,8 +77,7 @@ class BlogSectionsNode(template.Node):
         self.context_var = context_var
 
     def render(self, context):
-        sections = [(settings.PINAX_BLOG_ALL_SECTION_NAME, "All")]
-        sections += settings.PINAX_BLOG_SECTIONS
+        sections = Section.objects.filter(enabled=True)
         context[self.context_var] = sections
         return ""
 

--- a/pinax/blog/views.py
+++ b/pinax/blog/views.py
@@ -13,18 +13,21 @@ from django.contrib.sites.models import Site
 
 from .conf import settings
 from .exceptions import InvalidSection
-from .models import Post, FeedHit
+from .models import Post, FeedHit, Section
 from .signals import post_viewed, post_redirected
 
 
 def blog_index(request, section=None):
     if section:
         try:
-            posts = Post.objects.section(section)
+            posts = Post.objects.filter(section__slug=section)
+            section_object = get_object_or_404(Section,slug=section)
+
         except InvalidSection:
             raise Http404()
     else:
         posts = Post.objects.current()
+        section_object = None
 
     if request.GET.get("q"):
         posts = posts.filter(
@@ -38,7 +41,7 @@ def blog_index(request, section=None):
     return render_to_response("pinax/blog/blog_list.html", {
         "posts": posts,
         "section_slug": section,
-        "section_name": dict(Post.SECTION_CHOICES)[Post.section_idx(section)] if section else None,
+        "section_name": section_object.name if section else None,
         "search_term": request.GET.get("q")
     }, context_instance=RequestContext(request))
 
@@ -93,7 +96,7 @@ def serialize_request(request):
 def blog_feed(request, section=None, feed_type=None):
 
     try:
-        posts = Post.objects.section(section)
+        posts = Post.objects.filter(section__slug=section)
     except InvalidSection:
         raise Http404()
 

--- a/pinax/blog/views.py
+++ b/pinax/blog/views.py
@@ -21,7 +21,7 @@ def blog_index(request, section=None):
     if section:
         try:
             posts = Post.objects.filter(section__slug=section)
-            section_object = get_object_or_404(Section,slug=section)
+            section_object = get_object_or_404(Section, slug=section)
 
         except InvalidSection:
             raise Http404()


### PR DESCRIPTION
Move idx-based sections to model-based sections.

In this change we lost the "all" section, which was the default one, but it can be added by users manually.