### PR TITLE
Fixed urls.py entry

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Add `pinax-blog` to your `INSTALLED_APPS` setting:
 
 Add entry to your `urls.py`:
 
-    url(r"^/blog/", include("pinax.blog.urls"))
+    url(r"^blog/", include("pinax.blog.urls"))
 
 
 ## Dependencies


### PR DESCRIPTION
Using `url(r"^/blog/", include("pinax.blog.urls"))` results in an extra `/`, which means the blog will live at `http://example.com//blog/`.

Now that it's changed to `url(r"^blog/", include("pinax.blog.urls"))`, the blog will live at `http://example.com/blog/`.