### PR TITLE
Remove dependency on the Sites framework.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ for site-level company and project blogs, is now known as `pinax-blog`.
 !!! note "Pinax Ecosystem"
     This app was developed as part of the Pinax ecosystem but is just a Django app
     and can be used independently of other Pinax apps.
-    
+
     To learn more about Pinax, see <http://pinaxproject.com/>
 
 
@@ -27,6 +27,13 @@ Add `pinax-blog` to your `INSTALLED_APPS` setting:
 Add entry to your `urls.py`:
 
     url(r"^blog/", include("pinax.blog.urls"))
+
+If you aren't using the Django Sites framework you will need to add `CURRENT_SITE` to your project `settings.py`:
+
+    CURRENT_SITE = {
+        "name": "My site",
+        "domain": "example.com",
+    }
 
 
 ## Dependencies

--- a/pinax/blog/models.py
+++ b/pinax/blog/models.py
@@ -13,8 +13,6 @@ from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.html import strip_tags
 
-from django.contrib.sites.models import Site
-
 try:
     import twitter
 except ImportError:
@@ -24,7 +22,7 @@ import pytz
 
 from .conf import settings
 from .managers import PostManager
-from .utils import can_tweet
+from .utils import can_tweet, get_current_site
 
 try:
     from string import letters
@@ -139,7 +137,7 @@ class Post(models.Model):
 
     def as_tweet(self):
         if not self.tweet_text:
-            current_site = Site.objects.get_current()
+            current_site = get_current_site()
             api_url = "http://api.tr.im/api/trim_url.json"
             u = urlopen("%s?url=http://%s%s" % (
                 api_url,

--- a/pinax/blog/tests/tests.py
+++ b/pinax/blog/tests/tests.py
@@ -1,7 +1,17 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
+
+from pinax.blog.utils import get_current_site
 
 
 class Tests(TestCase):
 
-    def setUp(self):
-        pass
+    @override_settings(CURRENT_SITE=None)
+    def test_get_current_site(self):
+        site = get_current_site()
+        self.assertEqual(site.name, 'example.com')
+        self.assertEqual(site.domain, 'example.com')
+
+    def test_get_current_site_from_settings(self):
+        site = get_current_site()
+        self.assertEqual(site.name, 'Test site')
+        self.assertEqual(site.domain, 'http://test.example.com/')

--- a/pinax/blog/utils.py
+++ b/pinax/blog/utils.py
@@ -1,3 +1,4 @@
+from django.contrib.sites.models import Site
 from django.core.exceptions import ImproperlyConfigured
 try:
     from importlib import import_module
@@ -31,3 +32,11 @@ def load_path_attr(path):
     except AttributeError:
         raise ImproperlyConfigured("Module '%s' does not define a '%s'" % (module, attr))
     return attr
+
+
+def get_current_site():
+    if hasattr(settings, "CURRENT_SITE") and settings.CURRENT_SITE is not None:
+        return Site(name=settings.CURRENT_SITE['name'],
+                    domain=settings.CURRENT_SITE['domain'])
+    else:
+        return Site.objects.get_current()

--- a/pinax/blog/views.py
+++ b/pinax/blog/views.py
@@ -10,12 +10,11 @@ from django.template.loader import render_to_string
 from django.views.generic import DetailView, ListView
 from django.views.generic.dates import DateDetailView
 
-from django.contrib.sites.models import Site
-
 from .conf import settings
 from .managers import PUBLISHED_STATE
 from .models import Post, FeedHit, Section
 from .signals import post_viewed, post_redirected
+from .utils import get_current_site
 
 
 class BlogIndexView(ListView):
@@ -163,7 +162,7 @@ def blog_feed(request, section=None, feed_type=None):
     else:
         raise Http404()
 
-    current_site = Site.objects.get_current()
+    current_site = get_current_site()
     blog_url = "http://%s%s" % (current_site.domain, reverse("blog"))
     url_name, kwargs = "blog_feed", {"section": section.slug if section != "all" else "all", "feed_type": feed_type}
     feed_url = "http://%s%s" % (current_site.domain, reverse(url_name, kwargs=kwargs))

--- a/runtests.py
+++ b/runtests.py
@@ -24,6 +24,10 @@ DEFAULT_SETTINGS = dict(
     SITE_ID=1,
     ROOT_URLCONF="pinax.blog.tests.urls",
     SECRET_KEY="notasecret",
+    CURRENT_SITE={
+        "name": "Test site",
+        "domain": "http://test.example.com/",
+    },
 )
 
 


### PR DESCRIPTION
As Django 1.8 no longer requires the Sites framework this branch allows you to define the site in the settings instead.
