### PR TITLE
fix Image model import

### DIFF
--- a/pinax/blog/parsers/creole_parser.py
+++ b/pinax/blog/parsers/creole_parser.py
@@ -6,7 +6,7 @@ from pygments.formatters import HtmlFormatter
 from pygments.lexers import get_lexer_by_name, TextLexer
 from pygments.util import ClassNotFound
 
-from .models import Image
+from ..models import Image
 
 
 class Rules:


### PR DESCRIPTION
using Creole was causing an error with the parser because it couldn't import the Image model... had incorrect relative path `.models` instead of `..models`