### PR TITLE
add support for fenced_code extension

### DIFF
--- a/pinax/blog/parsers/markdown_parser.py
+++ b/pinax/blog/parsers/markdown_parser.py
@@ -21,7 +21,7 @@ class ImageLookupImagePattern(ImagePattern):
 
 
 def parse(text):
-    md = Markdown(extensions=["codehilite", "tables", "smarty", "admonition", "toc"])
+    md = Markdown(extensions=["codehilite", "tables", "smarty", "admonition", "toc", "fenced_code"])
     md.inlinePatterns["image_link"] = ImageLookupImagePattern(IMAGE_LINK_RE, md)
     html = md.convert(text)
     return html


### PR DESCRIPTION
the fenced_code extension (for Markdown) allows for github style triple-backtick code blocks as well as PHP "Extra" style code blocks. Seems like, in particular, folks expect github style code blocks to just work.

https://pythonhosted.org/Markdown/extensions/fenced_code_blocks.html
