### PR TITLE
Added dependency to docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,8 @@ Add `pinax-blog` to your `INSTALLED_APPS` setting:
         # ...
     )
 
+*Note*: Make sure you have `django.contrib.sites` also installed in `INSTALLED_APPS`
+
 Add entry to your `urls.py`:
 
     url(r"^blog/", include("pinax.blog.urls"))


### PR DESCRIPTION
In order to run `pinax-blog` you need to make sure you have
`django.contrib.sites` in `INSTALLED_APPS`. Otherwise you get
an error.