### PR TITLE
Update docs to use url namespace

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Add `pinax-blog` to your `INSTALLED_APPS` setting:
 
 Add entry to your `urls.py`:
 
-    url(r"^blog/", include("pinax.blog.urls"))
+    url(r"^blog/", include("pinax.blog.urls", namespace="pinax_blog"))
 
 
 ## Dependencies


### PR DESCRIPTION
Ref #84 
Updates docs example installation to use url with namespace `pinax_blog`