### PR TITLE
"scoped" context processor handling request.resolver_match when None

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 6.0.3
+
+* `scoped` context processor handles case when `request.resolver_match` is None
+
 ## 6.0.2
 
 * increased max_length of Post.slug field from 50 to 90 chars, matching Post.title field length.

--- a/pinax/blog/context_processors.py
+++ b/pinax/blog/context_processors.py
@@ -4,4 +4,5 @@ from .conf import settings
 def scoped(request):
     return {
         "scoper_lookup": request.resolver_match.kwargs.get(settings.PINAX_BLOG_SCOPING_URL_VAR)
+        if request.resolver_match else ""
     }

--- a/pinax/blog/tests/tests.py
+++ b/pinax/blog/tests/tests.py
@@ -5,11 +5,12 @@ import random
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
+from django.http.request import HttpRequest
 from django.test import TestCase
 from django.utils.text import slugify
 
 from ..models import Blog, Post, Section
-
+from ..context_processors import scoped
 
 ascii_lowercase = 'abcdefghijklmnopqrstuvwxyz'
 
@@ -127,3 +128,15 @@ class TestModelFieldValidation(TestBlog):
             .format(slug_len, len(slug)),
             the_exception.messages
         )
+
+
+class TestContextProcessors(TestBlog):
+
+    def test_no_resolver_match(self):
+        """
+        Ensure no problem when `request.resolver_match` is None
+        """
+        request = HttpRequest()
+        self.assertEqual(request.resolver_match, None)
+        result = scoped(request)
+        self.assertEqual(result, {"scoper_lookup": ""})

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ URL = "https://github.com/pinax/pinax-blog"
 
 setup(
     name=NAME,
-    version="6.0.2",
+    version="6.0.3",
     description=DESCRIPTION,
     long_description=read("README.rst"),
     url=URL,


### PR DESCRIPTION
Return empty string for "scoper_lookup" if request.resolver_match is None.