### PR TITLE
Restore and update guidance for pinax-images usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Add `pinax.blog.urls` to your project urlpatterns:
 URLs for adding and viewing images. They also use "bootstrap" formatting.
 
 In order to use these built-in templates, add `django-bootstrap-form` to your project requirements
-and ``"bootstrapform",` to your INSTALLED_APPS:
+and `"bootstrapform",` to your INSTALLED_APPS:
 
 ```python
     INSTALLED_APPS = [
@@ -128,7 +128,7 @@ and ``"bootstrapform",` to your INSTALLED_APPS:
     ]
 ```
 
-Then add pinax.images.urls` to your project urlpatterns:
+Then add `pinax.images.urls` to your project urlpatterns:
 
 ```python
     urlpatterns = [

--- a/README.md
+++ b/README.md
@@ -92,12 +92,13 @@ To install pinax-blog:
     $ pip install pinax-blog
 ```
 
-Add `pinax.blog` to your `INSTALLED_APPS` setting:
+Add `pinax.blog` and dependency `pinax.images` to your `INSTALLED_APPS` setting:
 
 ```python
     INSTALLED_APPS = [
         # other apps
         "pinax.blog",
+        "pinax.images",
     ]
 ```
 
@@ -110,7 +111,35 @@ Add `pinax.blog.urls` to your project urlpatterns:
     ]
 ```
 
-Optionally, if you want `creole` support for a mark up choice:
+### Optional Requirements
+
+`pinax-blog` ships with a few management view templates. These templates reference pinax-images
+URLs for adding and viewing images. They also use "bootstrap" formatting.
+
+In order to use these built-in templates, add `django-bootstrap-form` to your project requirements
+and ``"bootstrapform",` to your INSTALLED_APPS:
+
+```python
+    INSTALLED_APPS = [
+        # other apps
+        "pinax.blog",
+        "pinax.images",
+        "bootstrapform",
+    ]
+```
+
+Then add pinax.images.urls` to your project urlpatterns:
+
+```python
+    urlpatterns = [
+        # other urls
+        url(r"^blog/", include("pinax.blog.urls", namespace="pinax_blog")),
+        url(r"^ajax/images/", include("pinax.images.urls", namespace="pinax_images")),
+    ]
+```
+
+
+If you want `creole` support for mark-up:
 
 ```shell
     $ pip install creole
@@ -362,6 +391,10 @@ Both templates ship already configured to work out of the box.
 
 
 ## Change Log
+
+### 7.0.2
+
+* Restore and improve documentation guidance for pinax-images usage
 
 ### 7.0.1
 

--- a/pinax/blog/forms.py
+++ b/pinax/blog/forms.py
@@ -120,13 +120,24 @@ class PostForm(PostFormMixin, forms.ModelForm):
     teaser = forms.CharField(widget=forms.Textarea())
     content = forms.CharField(widget=forms.Textarea())
 
+    class Meta:
+        model = Post
+        fields = [
+            "section",
+            "title",
+            "teaser",
+            "content",
+            "description",
+            "state"
+        ]
+
     def __init__(self, *args, **kwargs):
         super(PostForm, self).__init__(*args, **kwargs)
         if Section.objects.count() < 2:
             self.section = Section.objects.first()
             del self.fields["section"]
         else:
-            self.section is None
+            self.section = None
 
     def save(self, blog=None, author=None):
         post = super(PostForm, self).save(commit=False)
@@ -140,14 +151,3 @@ class PostForm(PostFormMixin, forms.ModelForm):
         post.slug = slugify(post.title)
         post.markup = self.markup_choice
         return self.save_post(post)
-
-    class Meta:
-        model = Post
-        fields = [
-            "section",
-            "title",
-            "teaser",
-            "content",
-            "description",
-            "state"
-        ]

--- a/pinax/blog/tests/templates/site_base.html
+++ b/pinax/blog/tests/templates/site_base.html
@@ -1,0 +1,9 @@
+<div>
+{% block head_title %}
+Title
+{% endblock %}
+</div>
+<div>
+{% block body %}
+{% endblock %}
+</div>

--- a/pinax/blog/tests/urls.py
+++ b/pinax/blog/tests/urls.py
@@ -2,4 +2,5 @@ from django.conf.urls import include, url
 
 urlpatterns = [
     url(r"^", include("pinax.blog.urls", namespace="pinax_blog")),
+    url(r"^ajax/images/", include("pinax.images.urls", namespace="pinax_images")),
 ]

--- a/runtests.py
+++ b/runtests.py
@@ -12,11 +12,18 @@ DEFAULT_SETTINGS = dict(
     INSTALLED_APPS=[
         "django.contrib.auth",
         "django.contrib.contenttypes",
+        "django.contrib.sessions",
         "django.contrib.sites",
-        "pinax.images",
+
+        "bootstrapform",
         "pinax.blog",
         "pinax.blog.tests",
+        "pinax.images",
         "pinax.templates",
+    ],
+    MIDDLEWARE=[
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
     ],
     DATABASES={
         "default": {
@@ -30,11 +37,21 @@ DEFAULT_SETTINGS = dict(
     TEMPLATES=[
         {
             "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "DIRS": [
+                os.path.join(PACKAGE_ROOT, "templates"),
+            ],
             "APP_DIRS": True,
             "OPTIONS": {
                 "debug": True,
                 "context_processors": [
                     "django.contrib.auth.context_processors.auth",
+                    "django.template.context_processors.debug",
+                    "django.template.context_processors.i18n",
+                    "django.template.context_processors.media",
+                    "django.template.context_processors.static",
+                    "django.template.context_processors.tz",
+                    "django.template.context_processors.request",
+                    "django.contrib.messages.context_processors.messages",
                 ]
             }
         },

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "7.0.1"
+VERSION = "7.0.2"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-blog.svg
     :target: https://pypi.python.org/pypi/pinax-blog/
@@ -97,13 +97,16 @@ setup(
     install_requires=[
         "django>=1.11",
         "django-appconf>=1.0.1",
+        "markdown>=2.6.5",
+        "pillow>=3.0.0",
         "pinax-images>=3.0.1",
+        "pygments>=2.0.2",
         "pytz>=2016.6.1",
-        "Pillow>=3.0.0",
-        "Markdown>=2.6.5",
-        "Pygments>=2.0.2",
     ],
     tests_require=[
+        "django-bootstrap-form>=3.0.0",
+        "django-test-plus>=1.0.22",
+        "mock>=2.0.0",
         "pinax-templates>=1.0.0",
     ],
     test_suite="runtests.runtests",


### PR DESCRIPTION
Clarify `pinax-images` requirement, verify usage in tests.
Fix form initialization error.
Add django-test-plus testing dependency.
Update testing configuration for view tests and authentication.