### PR TITLE
Fixes an issue with post creation when certain ImageSet objects exist

### DIFF
--- a/pinax/blog/models.py
+++ b/pinax/blog/models.py
@@ -168,7 +168,7 @@ class Post(models.Model):
             self.secret_key = "".join(choice(letters) for _ in range(8))
         if self.is_published and self.published is None:
             self.published = timezone.now()
-        if not ImageSet.objects.filter(blog_post=self).exists():
+        if self.id is None or not ImageSet.objects.filter(blog_post=self).exists():
             self.image_set = ImageSet.objects.create(created_by=self.author)
         self.full_clean()
         super(Post, self).save(**kwargs)


### PR DESCRIPTION
Fixed an issue that caused post creation to fail if there was an ImageSet with a null Post reference. To reproduce the issue before merging, create an ImageSet while leaving the Post field null. Then try creating a Post and you'll get an error like so:

`ValidationError at /admin/blog/post/add/ {'image_set': ['This field cannot be null.']}`