### PR TITLE
Fix templates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     packages=find_packages(),
     package_data={
         "pinax.blog": [
-            "templates/pinax/blog/*.xml",
+            "templates/pinax/blog/*ml",
             "static/js/admin_post_form.js"
         ]
     },


### PR DESCRIPTION
Templates are currently excluded from the egg on installation, however, they aren't available in pinax-templates yet either, thus leaving to "Template not found" issues. This patches the `setup.py` to include the `html` and `xml`-files of the templates in the egg for now.