### PR TITLE
Fix Markdown requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,11 @@ Both templates ship already configured to work out of the box.
 
 ## Change Log
 
+### 7.0.4-image-reenabled
+
+* Reenable imagesets to be inline in the post creation
+* Fix Markdown 3 installation exception by changing to 2.6.11 which is the latest working version
+
 ### 7.0.3
 
 * Fix migration missing on_delete=

--- a/pinax/blog/admin.py
+++ b/pinax/blog/admin.py
@@ -46,7 +46,7 @@ class PostAdmin(admin.ModelAdmin):
         "sharable_url",
         "state",
         "published",
-        # "image_set"  # maybe this https://github.com/anziem/django_reverse_admin
+        "image_set"  # maybe this https://github.com/anziem/django_reverse_admin
     ]
     readonly_fields = ["sharable_url"]
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "7.0.4"
+VERSION = "7.0.4-image-reenabled"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-blog.svg
     :target: https://pypi.python.org/pypi/pinax-blog/

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     install_requires=[
         "django>=1.11",
         "django-appconf>=1.0.1",
-        "markdown>=2.6.5",
+        "markdown==2.6.11",
         "pillow>=3.0.0",
         "pinax-images>=3.0.1",
         "pygments>=2.0.2",


### PR DESCRIPTION
Markdown 3.0.1 (current version) does not work with Pinax-Blog.

`from markdown.inlinepatterns import IMAGE_LINK_RE, ImagePattern
ImportError: cannot import name 'ImagePattern' from 'markdown.inlinepatterns' ($PYTHONPATH$\lib\site-packages\markdown\inlinepatterns.py)`

Therefore I set the markdown install_requires in setup.py to 2.6.11 which is the latest working version.