### PR TITLE
curry dropped from django 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,10 @@ Both templates ship already configured to work out of the box.
 
 ## Change Log
 
+### 8.0.1
+
+* Change `from django.utils.functional import curry` to `from functools import partial as curry`
+
 ### 8.0.0
 
 * Drop Django 1.11, 2.0, and 2.1, and Python 2,7, 3.4, and 3.5 support

--- a/pinax/blog/admin.py
+++ b/pinax/blog/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.utils import timezone
-from django.utils.functional import curry
+from functools import partial as curry
 from django.utils.translation import ugettext_lazy as _
 
 from pinax.images.admin import ImageInline

--- a/pinax/blog/admin.py
+++ b/pinax/blog/admin.py
@@ -1,6 +1,7 @@
+from functools import partial as curry
+
 from django.contrib import admin
 from django.utils import timezone
-from functools import partial as curry
 from django.utils.translation import ugettext_lazy as _
 
 from pinax.images.admin import ImageInline

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "8.0.0"
+VERSION = "8.0.1"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-blog.svg
     :target: https://pypi.python.org/pypi/pinax-blog/


### PR DESCRIPTION
Closes #130  .

Changes proposed in this PR:

- import curry from functools as mentioned in https://code.djangoproject.com/ticket/10479

