### PR TITLE
upgrade markdown to 3.1.1

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Hugo David-Boyet <hugo.david.boyet@gmail.com>
 Benjamin Kampmann <ben.kampmann@googlemail.com>
 Merlin Dienst <merlin.dienst@gmail.com>
 Mfon Eti-mfon <mfonetimfon@gmail.com>
+Spencer Stecko <spencerstecko@gmail.com>

--- a/README.md
+++ b/README.md
@@ -399,6 +399,10 @@ Both templates ship already configured to work out of the box.
 
 ## Change Log
 
+### 8.1.0
+
+* Upgrade Markdown from 2.6.11 to 3.1.1
+
 ### 8.0.1
 
 * Change `from django.utils.functional import curry` to `from functools import partial as curry`

--- a/pinax/blog/parsers/markdown_parser.py
+++ b/pinax/blog/parsers/markdown_parser.py
@@ -1,9 +1,9 @@
 from markdown import Markdown
-from markdown.inlinepatterns import IMAGE_LINK_RE, ImagePattern
+from markdown.inlinepatterns import IMAGE_LINK_RE, ImageInlineProcessor
 from pinax.images.models import Image
 
 
-class ImageLookupImagePattern(ImagePattern):
+class ImageLookupImagePattern(ImageInlineProcessor):
 
     def sanitize_url(self, url):
         if url.startswith("http"):

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
     install_requires=[
         "django>=2.2",
         "django-appconf>=1.0.1",
-        "markdown==2.6.11",
+        "markdown==3.1.1",
         "pillow>=3.0.0",
         "pinax-images>=3.0.1",
         "pygments>=2.0.2",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = "8.0.1"
+VERSION = "8.1.0"
 LONG_DESCRIPTION = """
 .. image:: http://pinaxproject.com/pinax-design/patches/pinax-blog.svg
     :target: https://pypi.python.org/pypi/pinax-blog/


### PR DESCRIPTION
Closes # https://github.com/pinax/pinax-blog/issues/117

Changes proposed in this PR:

Upgrade the dependency on markdown and fix the startup issues that led to this upgrade being reverted. Many modern Django apps (such as django-wiki) require a higher version of Markdown. This makes it possible to use the pinax-blog in sites that also use such apps (like https://www.thecontractrpg.com !) 
